### PR TITLE
docs(NestJS): change server.js into main.js

### DIFF
--- a/01-JavaScript-Typescript-Backend/frameworks/nestjs/Dockerfile
+++ b/01-JavaScript-Typescript-Backend/frameworks/nestjs/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=builder --chown=node:node /home/node/package*.json ./
 COPY --from=builder --chown=node:node /home/node/node_modules/ ./node_modules/
 COPY --from=builder --chown=node:node /home/node/dist/ ./dist/
 
-CMD ["node", "dist/server.js"]
+CMD ["node", "dist/main.js"]

--- a/01-JavaScript-Typescript-Backend/frameworks/nestjs/README.md
+++ b/01-JavaScript-Typescript-Backend/frameworks/nestjs/README.md
@@ -103,6 +103,6 @@ COPY --from=builder --chown=node:node /home/node/yarn.lock ./
 ## The final step, add the startup command
 
 ```docker
-CMD ["node", "dist/server.js"]
+CMD ["node", "dist/main.js"]
 ```
 


### PR DESCRIPTION
in NestJS, instead of dist/server.js for running, dist/main.js should be used

## Changes Made Describe

the changes made to the codebase.

## Checklist
- [x] I have updated the README (if appropriate).
- [x] I have merged the latest changes from the main branch.
